### PR TITLE
fix the unpacking messages with long strings

### DIFF
--- a/lib/link.ex
+++ b/lib/link.ex
@@ -35,7 +35,7 @@ defmodule NVim.Link do
   defp reply(port,id,res), do: reply(port,id,{:ok,res})
 
   def parse_msgs(data,acc) do
-    case MessagePack.unpack_once(data, ext: NVim.Ext) do
+    case MessagePack.unpack_once(data, enable_string: true, ext: NVim.Ext) do
       {:ok,{msg,tail}}->parse_msgs(tail,[msg|acc])
       {:error,_}->{data,Enum.reverse(acc)}
     end

--- a/test/link_test.exs
+++ b/test/link_test.exs
@@ -1,0 +1,14 @@
+defmodule NVim.LinkTest do
+  use ExUnit.Case
+  alias NVim.Link
+
+  test "unpack messages with long string" do
+    message_pack_with_long_string = <<148, 0, 2, 164, 112, 111, 108, 108, 145, 145, 217, 32,
+    97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97,
+    97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97>>
+
+    {_, parsed_message} = NVim.Link.parse_msgs(message_pack_with_long_string, [])
+
+    assert parsed_message == [[0, 2, "poll", [["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]]]]
+  end
+end


### PR DESCRIPTION
Now it works on Ubuntu with any Elixir version.

In my case Neovim hanged up on call `:UpdateRemotePlugins`
