### PR TITLE
use :symbol for the backend param in logger config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,7 @@
 use Mix.Config
 
 config :logger,
-  backends: [if(Mix.env==:host, do: NVim.Logger, else: Logger.Backends.Console)],
+  backends: [if(Mix.env==:host, do: NVim.Logger, else: :console)],
   level: :debug,
   handle_otp_reports: true,
   handle_sasl_reports: true


### PR DESCRIPTION
to prevent the logger halting on test enviroment with Elixir ~> 1.1
